### PR TITLE
Add mock for end-of-line and remove dependency injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.eslintcache

--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Optionally, you can avoid specifying `plugins` in every schema by defining your 
 1. Create `jest.setup.js` in the root of your project. Provide [`plugins`](#plugins-arraystring) option to `getTestRule()`:
 
    ```js
-   const stylelint = require("stylelint");
    const getTestRule = require("jest-preset-stylelint/getTestRule");
 
-   global.testRule = getTestRule(stylelint, { plugins: ["./"] });
+   global.testRule = getTestRule({ plugins: ["./"] });
    ```
 
 2. Add `jest.setup.js` to your `jest.config.js` or `jest` field in `package.json`:

--- a/getTestRule.js
+++ b/getTestRule.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const util = require('util');
+const { basicChecks, lint } = require('stylelint');
 
-function getTestRule(injectedStylelint, options = {}) {
-	const basicChecks = injectedStylelint.basicChecks;
-	const stylelint = injectedStylelint.lint;
-
+function getTestRule(options = {}) {
 	return function testRule(schema) {
 		describe(`${schema.ruleName}`, () => {
 			const stylelintConfig = {
@@ -32,7 +30,7 @@ function getTestRule(injectedStylelint, options = {}) {
 						syntax: schema.syntax,
 					};
 
-					const output = await stylelint(options);
+					const output = await lint(options);
 
 					expect(output.results[0].warnings).toEqual([]);
 					expect(output.results[0].parseErrors).toEqual([]);
@@ -40,7 +38,7 @@ function getTestRule(injectedStylelint, options = {}) {
 					if (!schema.fix) return;
 
 					// Check that --fix doesn't change code
-					const outputAfterFix = await stylelint({ ...options, fix: true });
+					const outputAfterFix = await lint({ ...options, fix: true });
 					const fixedCode = getOutputCss(outputAfterFix);
 
 					expect(fixedCode).toBe(testCase.code);
@@ -58,7 +56,7 @@ function getTestRule(injectedStylelint, options = {}) {
 						syntax: schema.syntax,
 					};
 
-					const outputAfterLint = await stylelint(options);
+					const outputAfterLint = await lint(options);
 
 					const actualWarnings = outputAfterLint.results[0].warnings;
 
@@ -90,7 +88,7 @@ function getTestRule(injectedStylelint, options = {}) {
 						);
 					}
 
-					const outputAfterFix = await stylelint({ ...options, fix: true });
+					const outputAfterFix = await lint({ ...options, fix: true });
 
 					const fixedCode = getOutputCss(outputAfterFix);
 
@@ -107,7 +105,7 @@ function getTestRule(injectedStylelint, options = {}) {
 					}
 
 					// Checks whether only errors other than those fixed are reported
-					const outputAfterLintOnFixedCode = await stylelint({
+					const outputAfterLintOnFixedCode = await lint({
 						...options,
 						code: fixedCode,
 					});

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,6 +1,5 @@
 'use strict';
 
 const getTestRule = require('./getTestRule');
-const stylelint = require('stylelint');
 
-global.testRule = getTestRule(stylelint);
+global.testRule = getTestRule();

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Mock should be before stylelint required. Even if it's required inside other modules
+jest.mock('stylelint/lib/utils/getOsEol', () => () => '\n');
+
 const getTestRule = require('./getTestRule');
 
 global.testRule = getTestRule();


### PR DESCRIPTION
During https://github.com/stylelint/stylelint/pull/4758 I discovered `moduleNameMapper` option, which solves the problem that we solved with dependency injection. Use `testRule` with stylelint core, while `testRule` has `require('stylelint').

Also, there were a problem with tests on Windows if `"preset": "jest-preset-stylelint"` used. End-of-line mock didn't work.

I tested this PR with stylelint core and `stylelint-order`.