### PR TITLE
Add 'stylelintConfig' to the testRule schema

### DIFF
--- a/getTestRule.js
+++ b/getTestRule.js
@@ -11,6 +11,7 @@ function getTestRule(options = {}) {
 				rules: {
 					[schema.ruleName]: schema.config,
 				},
+				...schema.stylelintConfig,
 			};
 
 			let passingTestCases = schema.accept || [];


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This PR is a requirement for another PR: https://github.com/stylelint/stylelint/pull/4944

> Is there anything in the PR that needs further explanation?

This adds a 'stylelintConfig' property to the testRule schema, which allows for the following:

```js
testRule({
	ruleName,
	syntax: 'css-in-js',
	stylelintConfig: { unstable_substituteCssInJs: true },

    accept: [], // some meaningful tests here
});
```