### PR TITLE
Move to customSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.0.0
+
+- Removed: `syntax` schema property.
+- Added: `customSyntax` schema property.
+
 ## 3.0.0
 
 - Changed: `getTestRule` signature to only accept options as argument.

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Default: `false` (Optional).
 
 Skip [basic checks](https://github.com/stylelint/stylelint/blob/master/lib/testUtils/basicChecks.js), e.g. an empty source.
 
-### `syntax` \<string\>
+### `customSyntax` \<string\>
 
-Maps to stylelint's [`syntax` option](https://stylelint.io/user-guide/usage/options#syntax).
+Maps to stylelint's [`customSyntax` option](https://stylelint.io/user-guide/usage/options#customsyntax).
 
 ## Shared test case properties
 

--- a/getTestRule.js
+++ b/getTestRule.js
@@ -27,7 +27,7 @@ function getTestRule(options = {}) {
 					const stylelintOptions = {
 						code: testCase.code,
 						config: stylelintConfig,
-						syntax: schema.syntax,
+						customSyntax: schema.customSyntax,
 					};
 
 					const output = await lint(stylelintOptions);
@@ -53,7 +53,7 @@ function getTestRule(options = {}) {
 					const stylelintOptions = {
 						code: testCase.code,
 						config: stylelintConfig,
-						syntax: schema.syntax,
+						customSyntax: schema.customSyntax,
 					};
 
 					const outputAfterLint = await lint(stylelintOptions);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates to https://github.com/stylelint/stylelint/pull/5297

> Is there anything in the PR that needs further explanation?

Replaces the `syntax` option with the `customSyntax` one.
