### PR TITLE
Add `only` and `skip` for test groups

### DIFF
--- a/getTestRule.js
+++ b/getTestRule.js
@@ -3,7 +3,32 @@
 const util = require('util');
 const { basicChecks, lint } = require('stylelint');
 
+/**
+ * @typedef {Object} TestCase
+ * @property {string} code
+ * @property {string} [description]
+ * @property {boolean} [only]
+ * @property {boolean} [skip]
+ */
+
+/**
+ * @typedef {Object} TestSchema
+ * @property {string} ruleName
+ * @property {any} config
+ * @property {TestCase[]} accept
+ * @property {TestCase[]} reject
+ * @property {string | string[]} plugins
+ * @property {boolean} [skipBasicChecks]
+ * @property {boolean} [fix]
+ * @property {Syntax} [customSyntax] - PostCSS Syntax (https://postcss.org/api/#syntax)
+ * @property {boolean} [only]
+ * @property {boolean} [skip]
+ */
+
 function getTestRule(options = {}) {
+	/**
+	 * @param {TestSchema} schema
+	 */
 	return function testRule(schema) {
 		describe(`${schema.ruleName}`, () => {
 			const stylelintConfig = {
@@ -137,7 +162,9 @@ function getTestRule(options = {}) {
 
 function setupTestCases({ name, cases, schema, comparisons }) {
 	if (cases && cases.length) {
-		describe(`${name}`, () => {
+		const testGroup = schema.only ? describe.only : schema.skip ? describe.skip : describe;
+
+		testGroup(`${name}`, () => {
 			cases.forEach((testCase) => {
 				if (testCase) {
 					const spec = testCase.only ? it.only : testCase.skip ? it.skip : it;


### PR DESCRIPTION
This change adds `only` and `skip` options to run only a test group or skip a test group.

For example:

```js
testRule({
  ruleName,
  only: true,  // added
  skip: true,  // added
  accept: [ /* ... */ ],
  reject: [ /* ... */ ],
});
```

> Which issue, if any, is this issue related to?

Related to stylelint/stylelint#5297
I believe this change will provide a better way than commenting out.

> Is there anything in the PR that needs further explanation?

In addition, I've added JSDoc (#15) to understand the whole test options (it might not be sufficient, though).
I can remove it if anyone hopes to minimize the change.