### PR TITLE
Add ability to customise codeFilename

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Skip [basic checks](https://github.com/stylelint/stylelint/blob/master/lib/testU
 
 Maps to stylelint's [`customSyntax` option](https://stylelint.io/user-guide/usage/options#customsyntax).
 
+### `codeFilename` \<string\>
+
+Maps to stylelint's [`codeFilename` option](https://stylelint.io/user-guide/usage/options#codefilename).
+
 ## Shared test case properties
 
 Used within both `accept` and `reject` test cases.

--- a/getTestRule.js
+++ b/getTestRule.js
@@ -22,6 +22,7 @@ const { basicChecks, lint } = require('stylelint');
  * @property {boolean} [skipBasicChecks]
  * @property {boolean} [fix]
  * @property {Syntax} [customSyntax] - PostCSS Syntax (https://postcss.org/api/#syntax)
+ * @property {string} [codeFilename]
  * @property {boolean} [only]
  * @property {boolean} [skip]
  */
@@ -54,6 +55,7 @@ function getTestRule(options = {}) {
 						code: testCase.code,
 						config: stylelintConfig,
 						customSyntax: schema.customSyntax,
+						codeFilename: schema.codeFilename,
 					};
 
 					const output = await lint(stylelintOptions);
@@ -80,6 +82,7 @@ function getTestRule(options = {}) {
 						code: testCase.code,
 						config: stylelintConfig,
 						customSyntax: schema.customSyntax,
+						codeFilename: schema.codeFilename,
 					};
 
 					const outputAfterLint = await lint(stylelintOptions);


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

No existing issue.

This PR adds the ability to customise the [`codeFilename`](https://github.com/stylelint/stylelint/blob/060310cfd6383175ee06fe4d15aee27a4e202671/docs/user-guide/usage/options.md#codefilename) option that is passed into the stylelint options.

Over in the [stylelint-prettier](https://github.com/prettier/stylelint-prettier) plugin I change behaviour based up on in inputted code filename (I want to ignore cases like style blocks in html files where prettier can handle the whole file, not just style blocks within it).

Currently I'm using a forked version of `testRule()` that includes the change in this PR. With this PR I'd be able to use the `testRule()` provided by jest-preset-stylelint.

> Is there anything in the PR that needs further explanation?

No
