### PR TITLE
Fix target branch from `master` to `main` on CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,14 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - 'dependabot/**'
   pull_request:
     branches:
       - '**'
-
-env:
-  CI: true
 
 jobs:
   lint:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a CI configuration fix.

> Is there anything in the PR that needs further explanation?

This change also removes `env.CI: true` because it's set by default.
