### PR TITLE
Fix incorrect the `TestSchema.config` property type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ export type TestSchema = {
 	/**
 	 * Config to pass to the rule.
 	 */
-	config: unknown[];
+	config: unknown;
 
 	/**
 	 * Accept test cases.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #40

> Is there anything in the PR that needs further explanation?

The `TestSchema.config` property allows also a single value, not only an array.

E.g. on VSCode:

<img width="644" alt="Screen Shot 2022-02-25 at 0 01 33" src="https://user-images.githubusercontent.com/473530/155549913-b010cb7a-cd4b-4985-abf9-fd09d40d7515.png">

https://github.com/stylelint/stylelint/blob/653958a95272ce75e5e0b24544378d46b1eda93f/lib/rules/at-rule-allowed-list/__tests__/index.js#L82