### PR TITLE
Fix false negatives for `invalidOptionWarnings`

### DIFF
--- a/getTestRule.js
+++ b/getTestRule.js
@@ -36,6 +36,7 @@ module.exports = function getTestRule(options = {}) {
 
 					expect(output.results[0].warnings).toEqual([]);
 					expect(output.results[0].parseErrors).toEqual([]);
+					expect(output.results[0].invalidOptionWarnings).toEqual([]);
 
 					if (!schema.fix) return;
 
@@ -61,7 +62,10 @@ module.exports = function getTestRule(options = {}) {
 
 					const outputAfterLint = await lint(stylelintOptions);
 
-					const actualWarnings = outputAfterLint.results[0].warnings;
+					const actualWarnings = [
+						...outputAfterLint.results[0].invalidOptionWarnings,
+						...outputAfterLint.results[0].warnings,
+					];
 
 					expect(outputAfterLint.results[0]).toMatchObject({ parseErrors: [] });
 					expect(actualWarnings).toHaveLength(testCase.warnings ? testCase.warnings.length : 1);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #58 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
