### PR TITLE
Add support for custom unfixable error messages

### DIFF
--- a/getTestRule.js
+++ b/getTestRule.js
@@ -117,6 +117,7 @@ module.exports = function getTestRule(options = {}) {
 					const outputAfterLintOnFixedCode = await lint({
 						...stylelintOptions,
 						code: fixedCode,
+						fix: testCase.unfixable,
 					});
 
 					expect(outputAfterLintOnFixedCode.results[0]).toMatchObject({


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #60 

> Is there anything in the PR that needs further explanation?

This sets `fix` options to `unfixable` for the second assertion of the rejection.
That customizable autifix errors don't fail my tests here:
https://github.com/AndyOGo/stylelint-declaration-strict-value/pull/310

Not sure if that change is suitable for all plugins 🤔 
