### PR TITLE
Add `invalidConfig` schema property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: `invalidConfig` schema property.
+
 ## 6.1.1
 
 - Fixed: tightly-coupled dependency on Stylelint's internal module `lib/utils/getOsEol`.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ testRule({
   plugins: ["."],
   ruleName,
   config: [true, { type: "kebab" }],
+  invalidConfig: [123],
   fix: true,
 
   accept: [

--- a/__tests__/fixtures/plugin-foo.js
+++ b/__tests__/fixtures/plugin-foo.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const stylelint = require('stylelint');
+
+const ruleName = 'plugin/foo';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+	rejected: (selector) => `No "${selector}" selector`,
+});
+
+/** @type {(value: unknown) => boolean} */
+const isString = (value) => typeof value === 'string';
+
+/** @type {import('stylelint').Rule} */
+const ruleFunction = (primary) => {
+	return (root, result) => {
+		const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+			actual: primary,
+			possible: [isString],
+		});
+
+		if (!validOptions) {
+			return;
+		}
+
+		root.walkRules((rule) => {
+			const { selector } = rule;
+
+			if (primary !== selector) {
+				stylelint.utils.report({
+					result,
+					ruleName,
+					message: messages.rejected(selector),
+					node: rule,
+				});
+			}
+		});
+	};
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);

--- a/__tests__/getTestRule.test.js
+++ b/__tests__/getTestRule.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const getTestRule = require('../getTestRule.js');
+
+const testRule = getTestRule();
+
+testRule({
+	plugins: [require.resolve('./fixtures/plugin-foo.js')],
+	ruleName: 'plugin/foo',
+	config: ['.a'],
+	invalidConfig: [123],
+
+	accept: [
+		{
+			code: '.a {}',
+		},
+	],
+
+	reject: [
+		{
+			code: '#a {}',
+			message: 'No "#a" selector (plugin/foo)',
+		},
+	],
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,11 @@ export type TestSchema = {
 	config: unknown;
 
 	/**
+	 * Invalid configs to pass to the rule.
+	 */
+	invalidConfig?: unknown;
+
+	/**
 	 * Accept test cases.
 	 */
 	accept?: AcceptTestCase[];

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
       "@stylelint/remark-preset"
     ]
   },
+  "jest": {
+    "preset": "./jest-preset.js",
+    "testRegex": ".*\\.test\\.js$"
+  },
   "devDependencies": {
     "@stylelint/prettier-config": "^3.0.0",
     "@stylelint/remark-preset": "^4.0.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change adds a new schema property to test an invalid rule configuration.

Usage:

```js
testRule({
	ruleName,
	config: ['number'],
	invalidConfig: ['foo'],
	accept: [/*...*/],
	reject: [/*...*/],
});
```
