### PR TITLE
Add `loadLint` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: `loadLint` option.
+
 ## 6.2.0
 
 - Added: `testRuleConfigs` function.

--- a/__tests__/getTestRule.test.js
+++ b/__tests__/getTestRule.test.js
@@ -3,10 +3,12 @@
 const getTestRule = require('../getTestRule.js');
 
 const testRule = getTestRule();
+const plugins = [require.resolve('./fixtures/plugin-foo.js')];
+const ruleName = 'plugin/foo';
 
 testRule({
-	plugins: [require.resolve('./fixtures/plugin-foo.js')],
-	ruleName: 'plugin/foo',
+	plugins,
+	ruleName,
 	config: ['.a'],
 
 	accept: [
@@ -30,4 +32,23 @@ testRule({
 			description: 'with description',
 		},
 	],
+});
+
+testRule({
+	plugins,
+	ruleName,
+	config: ['.a'],
+	loadLint: () => Promise.resolve(require('stylelint').lint),
+	accept: [{ code: '.a {}' }],
+});
+
+const testRuleWithLoadLint = getTestRule({
+	loadLint: () => Promise.resolve(require('stylelint').lint),
+});
+
+testRuleWithLoadLint({
+	plugins,
+	ruleName,
+	config: ['.a'],
+	accept: [{ code: '.a {}' }],
 });

--- a/__tests__/getTestRuleConfigs.test.js
+++ b/__tests__/getTestRuleConfigs.test.js
@@ -3,10 +3,12 @@
 const getTestRuleConfigs = require('../getTestRuleConfigs.js');
 
 const testRuleConfigs = getTestRuleConfigs();
+const plugins = [require.resolve('./fixtures/plugin-foo.js')];
+const ruleName = 'plugin/foo';
 
 testRuleConfigs({
-	plugins: [require.resolve('./fixtures/plugin-foo.js')],
-	ruleName: 'plugin/foo',
+	plugins,
+	ruleName,
 
 	accept: [
 		{
@@ -27,4 +29,21 @@ testRuleConfigs({
 			description: 'regex is not allowed',
 		},
 	],
+});
+
+testRuleConfigs({
+	plugins,
+	ruleName,
+	loadLint: () => Promise.resolve(require('stylelint').lint),
+	accept: [{ config: 'a' }],
+});
+
+const testRuleConfigsWithLoadLint = getTestRuleConfigs({
+	loadLint: () => Promise.resolve(require('stylelint').lint),
+});
+
+testRuleConfigsWithLoadLint({
+	plugins,
+	ruleName,
+	accept: [{ config: 'a' }],
 });

--- a/getTestRule.js
+++ b/getTestRule.js
@@ -10,12 +10,14 @@ const util = require('util');
 /** @type {import('.').getTestRule} */
 module.exports = function getTestRule(options = {}) {
 	return function testRule(schema) {
+		const loadLint =
+			schema.loadLint || options.loadLint || (() => Promise.resolve(require('stylelint').lint)); // eslint-disable-line n/no-unpublished-require -- Avoid auto-install of `stylelint` peer dependency.
+
 		/** @type {import('stylelint').lint} */
 		let lint;
 
-		beforeAll(() => {
-			// eslint-disable-next-line n/no-unpublished-require -- Avoid auto-install of `stylelint` peer dependency.
-			lint = require('stylelint').lint;
+		beforeAll(async () => {
+			lint = await loadLint();
 		});
 
 		describe(`${schema.ruleName}`, () => {

--- a/getTestRuleConfigs.js
+++ b/getTestRuleConfigs.js
@@ -11,17 +11,20 @@ module.exports = function getTestRuleConfigs(options = {}) {
 		only = false,
 		skip = false,
 		plugins = options.plugins,
+		loadLint: schemaLoadLint,
 	}) {
 		if (accept.length === 0 && reject.length === 0) {
 			throw new TypeError('The either "accept" or "reject" property must not be empty');
 		}
 
+		const loadLint =
+			schemaLoadLint || options.loadLint || (() => Promise.resolve(require('stylelint').lint)); // eslint-disable-line n/no-unpublished-require -- Avoid auto-install of `stylelint` peer dependency.
+
 		/** @type {import('stylelint').lint} */
 		let lint;
 
-		beforeAll(() => {
-			// eslint-disable-next-line n/no-unpublished-require
-			lint = require('stylelint').lint;
+		beforeAll(async () => {
+			lint = await loadLint();
 		});
 
 		const testGroup = only ? describe.only : skip ? describe.skip : describe;

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,6 +144,16 @@ export type TestSchema = {
 	 * @see https://jestjs.io/docs/api#testskipname-fn
 	 */
 	skip?: boolean;
+
+	/**
+	 * Loads the lint function.
+	 */
+	loadLint?: () => Promise<import('stylelint').lint>;
+};
+
+type GetTestRuleOptions = {
+	plugins?: TestSchema['plugins'];
+	loadLint?: TestSchema['loadLint'];
 };
 
 /**
@@ -154,7 +164,7 @@ export type TestRule = (schema: TestSchema) => void;
 /**
  * Create a `testRule()` function with any specified plugins.
  */
-export function getTestRule(options?: { plugins?: TestSchema['plugins'] }): TestRule;
+export function getTestRule(options?: GetTestRuleOptions): TestRule;
 
 export type ConfigCase = {
 	config: unknown;
@@ -167,7 +177,7 @@ export type ConfigCase = {
  * Test configurations for a rule.
  */
 export type TestRuleConfigs = (
-	schema: Pick<TestSchema, 'ruleName' | 'plugins' | 'only' | 'skip'> & {
+	schema: Pick<TestSchema, 'ruleName' | 'plugins' | 'only' | 'skip' | 'loadLint'> & {
 		accept?: ConfigCase[];
 		reject?: ConfigCase[];
 	},
@@ -176,7 +186,7 @@ export type TestRuleConfigs = (
 /**
  * Create a `testRuleConfigs()` function with any specified plugins.
  */
-export function getTestRuleConfigs(options?: { plugins?: TestSchema['plugins'] }): TestRuleConfigs;
+export function getTestRuleConfigs(options?: GetTestRuleOptions): TestRuleConfigs;
 
 declare global {
 	var testRule: TestRule;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/5291

> Is there anything in the PR that needs further explanation?

This option allows to use the dynamic `import()` function. For example:

```js
{
  loadLint: () => import('stylelint').then((m) => m.default.lint)
}
```

