### PR TITLE
Fix `loadLint` option's type declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Fixed: `loadLint` option's type declaration.
+
 ## 6.3.0
 
 - Added: `loadLint` option.

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ export type TestSchema = {
 	/**
 	 * Loads the lint function.
 	 */
-	loadLint?: () => Promise<import('stylelint').lint>;
+	loadLint?: () => Promise<(typeof import('stylelint'))['lint']>;
 };
 
 type GetTestRuleOptions = {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This should resolve the error in <https://github.com/stylelint/stylelint/pull/7220>.

> Is there anything in the PR that needs further explanation?

Here's the error message:

```
Error: node_modules/jest-preset-stylelint/index.d.ts(151,47): error TS2694: Namespace 'stylelint' has no exported member 'lint'.
```

-- https://github.com/stylelint/stylelint/actions/runs/6451282281/job/17511705986?pr=7220#step:6:26