### PR TITLE
Fix missing `getTestRuleConfigs` export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Fixed: missing `getTestRuleConfigs` export.
+
 ## 6.3.1
 
 - Fixed: `loadLint` option's type declaration.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is useful if you have many tests. There are two additional steps to do this
 1. Create `jest.setup.js` in the root of your project. Provide `plugins` option to `getTestRule`/`getTestRuleConfigs`:
 
    ```js
-   const { getTestRule } = require("jest-preset-stylelint");
+   const { getTestRule, getTestRuleConfigs } = require("jest-preset-stylelint");
 
    global.testRule = getTestRule({ plugins: ["./"] });
    global.testRuleConfigs = getTestRuleConfigs({ plugins: ["./"] });

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `testRuleConfigs` function enables you to test invalid configs for a rule.
 For example:
 
 ```js
-testInvalidRuleConfigs({
+testRuleConfigs({
   plugins: ["."],
   ruleName,
 

--- a/__tests__/getTestRule.test.js
+++ b/__tests__/getTestRule.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getTestRule = require('../getTestRule.js');
+const { getTestRule } = require('../index.js');
 
 const testRule = getTestRule();
 const plugins = [require.resolve('./fixtures/plugin-foo.js')];

--- a/__tests__/getTestRuleConfigs.test.js
+++ b/__tests__/getTestRuleConfigs.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getTestRuleConfigs = require('../getTestRuleConfigs.js');
+const { getTestRuleConfigs } = require('../index.js');
 
 const testRuleConfigs = getTestRuleConfigs();
 const plugins = [require.resolve('./fixtures/plugin-foo.js')];

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
-const getTestRule = require('./getTestRule');
+const getTestRule = require('./getTestRule.js');
+const getTestRuleConfigs = require('./getTestRuleConfigs.js');
 
-module.exports = { getTestRule };
+module.exports = { getTestRule, getTestRuleConfigs };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
