### PR TITLE
Add `codeFilename` option to `accept`/`reject` cases in `testRule` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Added: `codeFilename` option to `accept`/`rejected` cases in `testRule` function.
+
 ## 7.0.1
 
 - Fixed: missing `funding` field in `package.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Head
 
-- Added: `codeFilename` option to `accept`/`rejected` cases in `testRule` function.
+- Added: `codeFilename` option to `accept`/`reject` cases in `testRule` function.
 
 ## 7.0.1
 

--- a/__tests__/fixtures/plugin-foo.mjs
+++ b/__tests__/fixtures/plugin-foo.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import stylelint from 'stylelint';
 
 const {
@@ -9,20 +11,46 @@ const ruleName = 'plugin/foo';
 
 const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `No "${selector}" selector`,
+	expectFilename: (expected, actual) => `Expect "${actual}" to be "${expected}"`,
 });
 
 /** @type {(value: unknown) => boolean} */
 const isString = (value) => typeof value === 'string';
 
 /** @type {import('stylelint').Rule} */
-const ruleFunction = (primary) => {
+const ruleFunction = (primary, secondaryOptions) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [isString],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: [isString],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					filename: [isString],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
+			return;
+		}
+
+		const expectedFilename = secondaryOptions?.filename;
+		const actualFilename = path.basename(root.source?.input.file ?? '');
+
+		if (expectedFilename && expectedFilename !== actualFilename) {
+			report({
+				result,
+				ruleName,
+				message: messages.expectFilename(expectedFilename, actualFilename),
+				node: root,
+			});
+
 			return;
 		}
 

--- a/__tests__/getTestRule.test.mjs
+++ b/__tests__/getTestRule.test.mjs
@@ -50,8 +50,9 @@ testRule({
 testRule({
 	plugins,
 	ruleName,
+	codeFilename: 'foo.css',
 	config: ['.a', { filename: 'foo.css' }],
-	accept: [{ code: '.a {}', codeFilename: 'foo.css' }],
+	accept: [{ code: '.a {}' }, { code: '.a {}', codeFilename: 'foo.css' }],
 	reject: [
 		{
 			code: '.a {}',

--- a/__tests__/getTestRule.test.mjs
+++ b/__tests__/getTestRule.test.mjs
@@ -47,6 +47,20 @@ testRule({
 	accept: [{ code: '.a {}' }],
 });
 
+testRule({
+	plugins,
+	ruleName,
+	config: ['.a', { filename: 'foo.css' }],
+	accept: [{ code: '.a {}', codeFilename: 'foo.css' }],
+	reject: [
+		{
+			code: '.a {}',
+			codeFilename: 'bar.css',
+			message: messages.expectFilename('foo.css', 'bar.css'),
+		},
+	],
+});
+
 const testRuleWithLoadLint = getTestRule({
 	loadLint: () => import('stylelint').then((m) => m.default.lint),
 });

--- a/getTestRule.js
+++ b/getTestRule.js
@@ -39,7 +39,7 @@ module.exports = function getTestRule(options = {}) {
 						code: testCase.code,
 						config: stylelintConfig,
 						customSyntax: schema.customSyntax,
-						codeFilename: schema.codeFilename,
+						codeFilename: testCase.codeFilename || schema.codeFilename,
 					};
 
 					const output = await lint(stylelintOptions);
@@ -67,7 +67,7 @@ module.exports = function getTestRule(options = {}) {
 						code: testCase.code,
 						config: stylelintConfig,
 						customSyntax: schema.customSyntax,
-						codeFilename: schema.codeFilename,
+						codeFilename: testCase.codeFilename || schema.codeFilename,
 					};
 
 					const outputAfterLint = await lint(stylelintOptions);

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,11 @@ export type TestCase = {
 	code: string;
 
 	/**
+	 * The filename for this `code` property.
+	 */
+	codeFilename?: string;
+
+	/**
 	 * Description of the test case.
 	 */
 	description?: string;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This new option is helpful when we want to change a top-level `codeFilename` in `accept`/`reject` cases. For example:

```js
testRule({
	codeFilename: 'foo.css',

	accept: [
		{
			code: 'a {}', // using 'foo.css'
		},
		{
			code: 'b {}',
			codeFilename: 'bar.css'
		},
	],
});
```

https://github.com/stylelint/jest-preset-stylelint/blob/315daed9c7f9381f924acdc13b2c87c75b11a160/index.d.ts#L127-L132

Ref https://stylelint.io/user-guide/options#codefilename