### PR TITLE
Fix false negatives when `fix` is missing and `computedEditInfo` is set to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased (patch)
+
+- Fixed: false negatives when `fix` is missing and `computedEditInfo` is set to `true`
+
 ## 7.2.0
 
 - Added: support for testing `computeEditInfo`.

--- a/__tests__/fixtures/plugin-foo.mjs
+++ b/__tests__/fixtures/plugin-foo.mjs
@@ -55,22 +55,25 @@ const ruleFunction = (primary, secondaryOptions) => {
 		}
 
 		root.walkRules((rule) => {
-			const { selector } = rule;
+			const { selectors } = rule;
 
-			if (primary !== selector) {
-				report({
-					result,
-					ruleName,
-					message: messages.rejected(selector),
-					node: rule,
-					fix: {
-						apply: () => {
-							rule.selector = primary;
-						},
+			selectors.forEach((selector, index) => {
+				if (primary !== selector) {
+					report({
+						result,
+						ruleName,
+						message: messages.rejected(selector),
 						node: rule,
-					},
-				});
-			}
+						fix: {
+							apply: () => {
+								selectors[index] = primary;
+								rule.selectors = selectors;
+							},
+							node: rule,
+						},
+					});
+				}
+			});
 		});
 	};
 };

--- a/__tests__/getTestRule.test.mjs
+++ b/__tests__/getTestRule.test.mjs
@@ -99,5 +99,20 @@ testRule({
 				text: '.',
 			},
 		},
+		{
+			code: '#a, #a {}',
+			warnings: [
+				{
+					message: messages.rejected('#a'),
+					fix: {
+						range: [0, 1],
+						text: '.',
+					},
+				},
+				{
+					message: messages.rejected('#a'),
+				},
+			],
+		},
 	],
 });

--- a/getTestRule.js
+++ b/getTestRule.js
@@ -97,6 +97,12 @@ module.exports = function getTestRule(options = {}) {
 						};
 
 						for (const [key, value] of Object.entries(expectedWarning)) {
+							if (schema.computeEditInfo && key === 'fix') {
+								// When `computeEditInfo` is set the test should only pass when `fix` matches the expected outcome,
+								// both in having a value and what the value is.
+								continue;
+							}
+
 							if (value === undefined) {
 								// @ts-expect-error -- Allow a partial object.
 								delete expectedWarning[key];


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/jest-preset-stylelint/issues/138

> Is there anything in the PR that needs further explanation?

@Mouvedia can you check this proposed change?
I think it resolves the linked issue.
