### PR TITLE
Test `fix` and `computeEditInfo` in the same `testRule` call

### DIFF
--- a/__tests__/getTestRule.test.mjs
+++ b/__tests__/getTestRule.test.mjs
@@ -101,3 +101,35 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	plugins,
+	ruleName,
+	config: ['.a'],
+	fix: true,
+	computeEditInfo: true,
+
+	accept: [],
+
+	reject: [
+		{
+			code: '#a {}',
+			fixed: '.a {}',
+			message: messages.rejected('#a'),
+			fix: {
+				range: [0, 1],
+				text: '.',
+			},
+		},
+		{
+			code: '.a {} #a {}',
+			fixed: '.a {} .a {}',
+			message: messages.rejected('#a'),
+			description: 'with description',
+			fix: {
+				range: [6, 7],
+				text: '.',
+			},
+		},
+	],
+});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/pull/8420#discussion_r1977755127

> Is there anything in the PR that needs further explanation?

This actually works fine and I think it could be handy to allow rule authors to have more test coverage with fewer lines of test code.
