### PR TITLE
Sync CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# https://help.github.com/articles/about-codeowners/
+
+# All proposed file changes under the `.github/` folder must be approved by the owners team prior to merging.
+.github/ @stylelint/owners
+
+# Require approvals by the owners team when updating dependencies or package metadata.
+package.json @stylelint/owners


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Since the CODEOWNERS file is not shared, we need to sync it manually.

Copied from https://github.com/stylelint/.github/blob/b6c85f6bfee221c9b75b138d18881da2d8d06138/.github/CODEOWNERS

Ref https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file
