### PR TITLE
Migrate to recommended `call-*` workflows

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   lint:
-    uses: stylelint/.github/.github/workflows/lint.yml@34f1c0ac91f245ee4ee5ce725bb844328c17ccf5 # 0.3.0
+    uses: stylelint/.github/.github/workflows/call-lint.yml@34f1c0ac91f245ee4ee5ce725bb844328c17ccf5 # 0.3.0
     permissions:
       contents: read
 
   test:
-    uses: stylelint/.github/.github/workflows/test.yml@34f1c0ac91f245ee4ee5ce725bb844328c17ccf5 # 0.3.0
+    uses: stylelint/.github/.github/workflows/call-test.yml@34f1c0ac91f245ee4ee5ce725bb844328c17ccf5 # 0.3.0
     with:
       node-version: '["20", "22", "24"]'
     permissions:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This resolves the deprecation warning below:

```
This workflow 'test.yml' is deprecated. Use 'call-test.yml' instead.
```

Ref https://github.com/stylelint/jest-preset-stylelint/actions/runs/18185108288
