### PR TITLE
Update CI workflow to use default Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
 
   test:
     uses: stylelint/.github/.github/workflows/call-test.yml@6ac761787832e417273f7bb071ec8cf35abcc3d6 # 1.0.0
-    with:
-      node-version: '["20", "22", "24"]'
     permissions:
       contents: read
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a workflow fix.

> Is there anything in the PR that needs further explanation?

Aligns this repo with our others, e.g. [recommended config](https://github.com/stylelint/stylelint-config-recommended/blob/6963658d69cb06a2a7e02d92748dec0d80513bd1/.github/workflows/ci.yml#L15-L18):

```
  test:
    uses: stylelint/.github/.github/workflows/call-test.yml@6ac761787832e417273f7bb071ec8cf35abcc3d6 # 1.0.0
    permissions:
      contents: read
```

Ref failing workflow run: https://github.com/stylelint/jest-preset-stylelint/actions/runs/30151991677/job/89684064071?pr=234
